### PR TITLE
Export flow types in build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "scripts": {
     "examples": "npm run build && babel-node examples/index.js",
-    "build": "babel src --ignore __tests__,*.test.js --out-dir dist/",
+    "build": "babel src --ignore __tests__,*.test.js --out-dir dist/ && npm run build-dot-flow",
+    "build-dot-flow": "find ./src -name '*.js' -not -path '*/__tests__*' -not -name '*.test.js' | while read filepath; do cp $filepath `echo $filepath | sed 's/\\/src\\//\\/dist\\//g'`.flow; done",
     "test": "npm run examples && npm run testonly && npm run check && npm run lint",
     "testonly": "jest",
     "watch": "jest --watch",


### PR DESCRIPTION
The build system has been updated to copy all the source files and add the .js.flow extension next to the .js files. This will allow flow to pick up the type definitions.