### PR TITLE
Do not transform valid input

### DIFF
--- a/src/date/index.js
+++ b/src/date/index.js
@@ -58,7 +58,7 @@ const config: GraphQLScalarTypeConfig<Date, string> = {
     }
 
     if (validateDate(value)) {
-      return parseDate(value)
+      return value;
     }
     throw new TypeError(
       `Date cannot represent an invalid date-string ${value}.`


### PR DESCRIPTION
This line changes 1979-08-15 to  1979-08-15T00:00:00.000Z which doesn’t match the RFC_3339_REGEX in validator.js

If it is correct that this date string is transformed to a datetime string, the fix should be made in the serialize function.
