### PR TITLE
Unify `parseValue()` & `parseLiteral()` across types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "graphql-iso-date",
   "version": "3.3.0",
   "description": "A set of RFC 3339 compliant date/time GraphQL scalar types.",
-  "main": "index.js",
+  "main": "dist/index.js",
   "homepage": "https://github.com/excitement-engineer/graphql-iso-date",
   "bugs": {
     "url": "https://github.com/excitement-engineer/graphql-iso-date/issues"

--- a/src/date/__snapshots__/index.test.js.snap
+++ b/src/date/__snapshots__/index.test.js.snap
@@ -2,11 +2,11 @@
 
 exports[`GraphQLDate has a description 1`] = `"A date string, such as 2007-12-03, compliant with the \`full-date\` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."`;
 
-exports[`GraphQLDate literal parsing throws error when parsing invalid literal {"kind": "FloatValue", "value": "5"} 1`] = `"Date cannot represent non string type null"`;
+exports[`GraphQLDate literal parsing throws error when parsing invalid literal {"kind": "FloatValue", "value": "5"} 1`] = `"Can't parse non-string type: null"`;
 
-exports[`GraphQLDate literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2015-02-29"} 1`] = `"Date cannot represent an invalid time-string \\"2015-02-29\\""`;
+exports[`GraphQLDate literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2015-02-29"} 1`] = `"Can't parse an invalid Date string: \\"2015-02-29\\""`;
 
-exports[`GraphQLDate literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "invalid date"} 1`] = `"Date cannot represent an invalid time-string \\"invalid date\\""`;
+exports[`GraphQLDate literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "invalid date"} 1`] = `"Can't parse an invalid Date string: \\"invalid date\\""`;
 
 exports[`GraphQLDate serialization throws an error when serializing an invalid date-string "2015-02-29" 1`] = `"Date cannot represent an invalid date-string 2015-02-29."`;
 
@@ -24,16 +24,16 @@ exports[`GraphQLDate serialization throws error when serializing true 1`] = `"Da
 
 exports[`GraphQLDate serialization throws error when serializing undefined 1`] = `"Date cannot represent a non string, or non Date type undefined"`;
 
-exports[`GraphQLDate value parsing throws an error parsing an invalid datetime-string "2015-02-29" 1`] = `"Date cannot represent an invalid time-string \\"2015-02-29\\""`;
+exports[`GraphQLDate value parsing throws an error parsing an invalid datetime-string "2015-02-29" 1`] = `"Can't parse an invalid Date string: \\"2015-02-29\\""`;
 
-exports[`GraphQLDate value parsing throws an error parsing an invalid datetime-string "invalid date" 1`] = `"Date cannot represent an invalid time-string \\"invalid date\\""`;
+exports[`GraphQLDate value parsing throws an error parsing an invalid datetime-string "invalid date" 1`] = `"Can't parse an invalid Date string: \\"invalid date\\""`;
 
-exports[`GraphQLDate value parsing throws an error when parsing [] 1`] = `"Date cannot represent non string type []"`;
+exports[`GraphQLDate value parsing throws an error when parsing [] 1`] = `"Can't parse non-string type: []"`;
 
-exports[`GraphQLDate value parsing throws an error when parsing {} 1`] = `"Date cannot represent non string type {}"`;
+exports[`GraphQLDate value parsing throws an error when parsing {} 1`] = `"Can't parse non-string type: {}"`;
 
-exports[`GraphQLDate value parsing throws an error when parsing 4566 1`] = `"Date cannot represent non string type 4566"`;
+exports[`GraphQLDate value parsing throws an error when parsing 4566 1`] = `"Can't parse non-string type: 4566"`;
 
-exports[`GraphQLDate value parsing throws an error when parsing null 1`] = `"Date cannot represent non string type null"`;
+exports[`GraphQLDate value parsing throws an error when parsing null 1`] = `"Can't parse non-string type: null"`;
 
-exports[`GraphQLDate value parsing throws an error when parsing true 1`] = `"Date cannot represent non string type true"`;
+exports[`GraphQLDate value parsing throws an error when parsing true 1`] = `"Can't parse non-string type: true"`;

--- a/src/date/__snapshots__/index.test.js.snap
+++ b/src/date/__snapshots__/index.test.js.snap
@@ -2,6 +2,12 @@
 
 exports[`GraphQLDate has a description 1`] = `"A date string, such as 2007-12-03, compliant with the \`full-date\` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."`;
 
+exports[`GraphQLDate literal parsing throws error when parsing invalid literal {"kind": "FloatValue", "value": "5"} 1`] = `"Date cannot represent non string type null"`;
+
+exports[`GraphQLDate literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2015-02-29"} 1`] = `"Date cannot represent an invalid time-string \\"2015-02-29\\""`;
+
+exports[`GraphQLDate literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "invalid date"} 1`] = `"Date cannot represent an invalid time-string \\"invalid date\\""`;
+
 exports[`GraphQLDate serialization throws an error when serializing an invalid date-string "2015-02-29" 1`] = `"Date cannot represent an invalid date-string 2015-02-29."`;
 
 exports[`GraphQLDate serialization throws an error when serializing an invalid date-string "invalid date" 1`] = `"Date cannot represent an invalid date-string invalid date."`;
@@ -18,9 +24,9 @@ exports[`GraphQLDate serialization throws error when serializing true 1`] = `"Da
 
 exports[`GraphQLDate serialization throws error when serializing undefined 1`] = `"Date cannot represent a non string, or non Date type undefined"`;
 
-exports[`GraphQLDate value parsing throws an error parsing an invalid datetime-string "2015-02-29" 1`] = `"Date cannot represent an invalid date-string 2015-02-29."`;
+exports[`GraphQLDate value parsing throws an error parsing an invalid datetime-string "2015-02-29" 1`] = `"Date cannot represent an invalid time-string \\"2015-02-29\\""`;
 
-exports[`GraphQLDate value parsing throws an error parsing an invalid datetime-string "invalid date" 1`] = `"Date cannot represent an invalid date-string invalid date."`;
+exports[`GraphQLDate value parsing throws an error parsing an invalid datetime-string "invalid date" 1`] = `"Date cannot represent an invalid time-string \\"invalid date\\""`;
 
 exports[`GraphQLDate value parsing throws an error when parsing [] 1`] = `"Date cannot represent non string type []"`;
 

--- a/src/date/index.test.js
+++ b/src/date/index.test.js
@@ -117,7 +117,7 @@ describe('GraphQLDate', () => {
     })
   })
 
-  describe('literial parsing', () => {
+  describe('literal parsing', () => {
     validDates.forEach(([ value, expected ]) => {
       const literal = {
         kind: Kind.STRING, value
@@ -134,20 +134,20 @@ describe('GraphQLDate', () => {
       const invalidLiteral = {
         kind: Kind.STRING, value
       }
-      it(`returns null when parsing invalid literal ${stringify(invalidLiteral)}`, () => {
-        expect(
+      it(`throws error when parsing invalid literal ${stringify(invalidLiteral)}`, () => {
+        expect(() =>
           GraphQLDate.parseLiteral(invalidLiteral)
-        ).toEqual(null)
+        ).toThrowErrorMatchingSnapshot()
       })
     })
 
     const invalidLiteralFloat = {
       kind: Kind.FLOAT, value: '5'
     }
-    it(`returns null when parsing invalid literal ${stringify(invalidLiteralFloat)}`, () => {
-      expect(
+    it(`throws error when parsing invalid literal ${stringify(invalidLiteralFloat)}`, () => {
+      expect(() =>
         GraphQLDate.parseLiteral(invalidLiteralFloat)
-      ).toEqual(null)
+      ).toThrowErrorMatchingSnapshot()
     })
   })
 })

--- a/src/dateTime/__snapshots__/index.test.js.snap
+++ b/src/dateTime/__snapshots__/index.test.js.snap
@@ -2,6 +2,20 @@
 
 exports[`GraphQLDateTime has a description 1`] = `"A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the \`date-time\` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."`;
 
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "FloatValue", "value": "5"} 1`] = `"DateTime cannot represent non string type null"`;
+
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2015-02-24T00:00:00.000+0100"} 1`] = `"DateTime cannot represent an invalid time-string \\"2015-02-24T00:00:00.000+0100\\""`;
+
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T00:00:00.Z"} 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T00:00:00.Z\\""`;
+
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T00:00Z"} 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T00:00Z\\""`;
+
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T000059Z"} 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T000059Z\\""`;
+
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T00Z"} 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T00Z\\""`;
+
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "Invalid date"} 1`] = `"DateTime cannot represent an invalid time-string \\"Invalid date\\""`;
+
 exports[`GraphQLDateTime serialization throws an error serializing the invalid unix timestamp -2147483649 1`] = `"DateTime cannot represent an invalid Unix timestamp -2147483649"`;
 
 exports[`GraphQLDateTime serialization throws an error serializing the invalid unix timestamp 2147483648 1`] = `"DateTime cannot represent an invalid Unix timestamp 2147483648"`;
@@ -36,17 +50,17 @@ exports[`GraphQLDateTime serialization throws error when serializing true 1`] = 
 
 exports[`GraphQLDateTime serialization throws error when serializing undefined 1`] = `"DateTime cannot be serialized from a non string, non numeric or non Date type undefined"`;
 
-exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2015-02-24T00:00:00.000+0100" 1`] = `"DateTime cannot represent an invalid date-time-string 2015-02-24T00:00:00.000+0100."`;
+exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2015-02-24T00:00:00.000+0100" 1`] = `"DateTime cannot represent an invalid time-string \\"2015-02-24T00:00:00.000+0100\\""`;
 
-exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T00:00:00.Z" 1`] = `"DateTime cannot represent an invalid date-time-string 2016-02-01T00:00:00.Z."`;
+exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T00:00:00.Z" 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T00:00:00.Z\\""`;
 
-exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T00:00Z" 1`] = `"DateTime cannot represent an invalid date-time-string 2016-02-01T00:00Z."`;
+exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T00:00Z" 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T00:00Z\\""`;
 
-exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T000059Z" 1`] = `"DateTime cannot represent an invalid date-time-string 2016-02-01T000059Z."`;
+exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T000059Z" 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T000059Z\\""`;
 
-exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T00Z" 1`] = `"DateTime cannot represent an invalid date-time-string 2016-02-01T00Z."`;
+exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T00Z" 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T00Z\\""`;
 
-exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "Invalid date" 1`] = `"DateTime cannot represent an invalid date-time-string Invalid date."`;
+exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "Invalid date" 1`] = `"DateTime cannot represent an invalid time-string \\"Invalid date\\""`;
 
 exports[`GraphQLDateTime value parsing throws an error when parsing [] 1`] = `"DateTime cannot represent non string type []"`;
 

--- a/src/dateTime/__snapshots__/index.test.js.snap
+++ b/src/dateTime/__snapshots__/index.test.js.snap
@@ -2,19 +2,19 @@
 
 exports[`GraphQLDateTime has a description 1`] = `"A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the \`date-time\` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."`;
 
-exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "FloatValue", "value": "5"} 1`] = `"DateTime cannot represent non string type null"`;
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "FloatValue", "value": "5"} 1`] = `"Can't parse non-string type: null"`;
 
-exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2015-02-24T00:00:00.000+0100"} 1`] = `"DateTime cannot represent an invalid time-string \\"2015-02-24T00:00:00.000+0100\\""`;
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2015-02-24T00:00:00.000+0100"} 1`] = `"Can't parse an invalid DateTime string: \\"2015-02-24T00:00:00.000+0100\\""`;
 
-exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T00:00:00.Z"} 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T00:00:00.Z\\""`;
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T00:00:00.Z"} 1`] = `"Can't parse an invalid DateTime string: \\"2016-02-01T00:00:00.Z\\""`;
 
-exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T00:00Z"} 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T00:00Z\\""`;
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T00:00Z"} 1`] = `"Can't parse an invalid DateTime string: \\"2016-02-01T00:00Z\\""`;
 
-exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T000059Z"} 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T000059Z\\""`;
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T000059Z"} 1`] = `"Can't parse an invalid DateTime string: \\"2016-02-01T000059Z\\""`;
 
-exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T00Z"} 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T00Z\\""`;
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T00Z"} 1`] = `"Can't parse an invalid DateTime string: \\"2016-02-01T00Z\\""`;
 
-exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "Invalid date"} 1`] = `"DateTime cannot represent an invalid time-string \\"Invalid date\\""`;
+exports[`GraphQLDateTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "Invalid date"} 1`] = `"Can't parse an invalid DateTime string: \\"Invalid date\\""`;
 
 exports[`GraphQLDateTime serialization throws an error serializing the invalid unix timestamp -2147483649 1`] = `"DateTime cannot represent an invalid Unix timestamp -2147483649"`;
 
@@ -50,24 +50,24 @@ exports[`GraphQLDateTime serialization throws error when serializing true 1`] = 
 
 exports[`GraphQLDateTime serialization throws error when serializing undefined 1`] = `"DateTime cannot be serialized from a non string, non numeric or non Date type undefined"`;
 
-exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2015-02-24T00:00:00.000+0100" 1`] = `"DateTime cannot represent an invalid time-string \\"2015-02-24T00:00:00.000+0100\\""`;
+exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2015-02-24T00:00:00.000+0100" 1`] = `"Can't parse an invalid DateTime string: \\"2015-02-24T00:00:00.000+0100\\""`;
 
-exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T00:00:00.Z" 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T00:00:00.Z\\""`;
+exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T00:00:00.Z" 1`] = `"Can't parse an invalid DateTime string: \\"2016-02-01T00:00:00.Z\\""`;
 
-exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T00:00Z" 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T00:00Z\\""`;
+exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T00:00Z" 1`] = `"Can't parse an invalid DateTime string: \\"2016-02-01T00:00Z\\""`;
 
-exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T000059Z" 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T000059Z\\""`;
+exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T000059Z" 1`] = `"Can't parse an invalid DateTime string: \\"2016-02-01T000059Z\\""`;
 
-exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T00Z" 1`] = `"DateTime cannot represent an invalid time-string \\"2016-02-01T00Z\\""`;
+exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "2016-02-01T00Z" 1`] = `"Can't parse an invalid DateTime string: \\"2016-02-01T00Z\\""`;
 
-exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "Invalid date" 1`] = `"DateTime cannot represent an invalid time-string \\"Invalid date\\""`;
+exports[`GraphQLDateTime value parsing throws an error parsing an invalid date-string "Invalid date" 1`] = `"Can't parse an invalid DateTime string: \\"Invalid date\\""`;
 
-exports[`GraphQLDateTime value parsing throws an error when parsing [] 1`] = `"DateTime cannot represent non string type []"`;
+exports[`GraphQLDateTime value parsing throws an error when parsing [] 1`] = `"Can't parse non-string type: []"`;
 
-exports[`GraphQLDateTime value parsing throws an error when parsing {} 1`] = `"DateTime cannot represent non string type {}"`;
+exports[`GraphQLDateTime value parsing throws an error when parsing {} 1`] = `"Can't parse non-string type: {}"`;
 
-exports[`GraphQLDateTime value parsing throws an error when parsing 4566 1`] = `"DateTime cannot represent non string type 4566"`;
+exports[`GraphQLDateTime value parsing throws an error when parsing 4566 1`] = `"Can't parse non-string type: 4566"`;
 
-exports[`GraphQLDateTime value parsing throws an error when parsing null 1`] = `"DateTime cannot represent non string type null"`;
+exports[`GraphQLDateTime value parsing throws an error when parsing null 1`] = `"Can't parse non-string type: null"`;
 
-exports[`GraphQLDateTime value parsing throws an error when parsing true 1`] = `"DateTime cannot represent non string type true"`;
+exports[`GraphQLDateTime value parsing throws an error when parsing true 1`] = `"Can't parse non-string type: true"`;

--- a/src/dateTime/index.test.js
+++ b/src/dateTime/index.test.js
@@ -172,7 +172,7 @@ describe('GraphQLDateTime', () => {
     })
   })
 
-  describe('literial parsing', () => {
+  describe('literal parsing', () => {
     validDates.forEach(([ value, expected ]) => {
       const literal = {
         kind: Kind.STRING, value
@@ -189,20 +189,20 @@ describe('GraphQLDateTime', () => {
       const invalidLiteral = {
         kind: Kind.STRING, value
       }
-      it(`returns null when parsing invalid literal ${stringify(invalidLiteral)}`, () => {
-        expect(
+      it(`throws error when parsing invalid literal ${stringify(invalidLiteral)}`, () => {
+        expect(() =>
           GraphQLDateTime.parseLiteral(invalidLiteral)
-        ).toEqual(null)
+        ).toThrowErrorMatchingSnapshot()
       })
     })
 
     const invalidLiteralFloat = {
       kind: Kind.FLOAT, value: '5'
     }
-    it(`returns null when parsing invalid literal ${stringify(invalidLiteralFloat)}`, () => {
-      expect(
+    it(`throws error when parsing invalid literal ${stringify(invalidLiteralFloat)}`, () => {
+      expect(() =>
         GraphQLDateTime.parseLiteral(invalidLiteralFloat)
-      ).toEqual(null)
+      ).toThrowErrorMatchingSnapshot()
     })
   })
 })

--- a/src/time/__snapshots__/index.test.js.snap
+++ b/src/time/__snapshots__/index.test.js.snap
@@ -2,6 +2,18 @@
 
 exports[`GraphQLTime has a description 1`] = `"A time string at UTC, such as 10:15:30Z, compliant with the \`full-time\` format outlined in section 5.6 of the RFC 3339profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."`;
 
+exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "FloatValue", "value": "5"} 1`] = `"Time cannot represent non string type null"`;
+
+exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "00:00:00.45+01"} 1`] = `"Time cannot represent an invalid time-string \\"00:00:00.45+01\\""`;
+
+exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "00:00:00.45+0130"} 1`] = `"Time cannot represent an invalid time-string \\"00:00:00.45+0130\\""`;
+
+exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "10:30:02.Z"} 1`] = `"Time cannot represent an invalid time-string \\"10:30:02.Z\\""`;
+
+exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-01-01T00:00:00.223Z"} 1`] = `"Time cannot represent an invalid time-string \\"2016-01-01T00:00:00.223Z\\""`;
+
+exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "Invalid date"} 1`] = `"Time cannot represent an invalid time-string \\"Invalid date\\""`;
+
 exports[`GraphQLTime serialization throws an error when serializing an invalid date-string "00:00:00.45+01" 1`] = `"Time cannot represent an invalid time-string 00:00:00.45+01."`;
 
 exports[`GraphQLTime serialization throws an error when serializing an invalid date-string "00:00:00.45+0130" 1`] = `"Time cannot represent an invalid time-string 00:00:00.45+0130."`;
@@ -24,15 +36,15 @@ exports[`GraphQLTime serialization throws error when serializing true 1`] = `"Ti
 
 exports[`GraphQLTime serialization throws error when serializing undefined 1`] = `"Time cannot be serialized from a non string, or non Date type undefined"`;
 
-exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "00:00:00.45+01" 1`] = `"Time cannot represent an invalid time-string 00:00:00.45+01."`;
+exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "00:00:00.45+01" 1`] = `"Time cannot represent an invalid time-string \\"00:00:00.45+01\\""`;
 
-exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "00:00:00.45+0130" 1`] = `"Time cannot represent an invalid time-string 00:00:00.45+0130."`;
+exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "00:00:00.45+0130" 1`] = `"Time cannot represent an invalid time-string \\"00:00:00.45+0130\\""`;
 
-exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "10:30:02.Z" 1`] = `"Time cannot represent an invalid time-string 10:30:02.Z."`;
+exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "10:30:02.Z" 1`] = `"Time cannot represent an invalid time-string \\"10:30:02.Z\\""`;
 
-exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "2016-01-01T00:00:00.223Z" 1`] = `"Time cannot represent an invalid time-string 2016-01-01T00:00:00.223Z."`;
+exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "2016-01-01T00:00:00.223Z" 1`] = `"Time cannot represent an invalid time-string \\"2016-01-01T00:00:00.223Z\\""`;
 
-exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "Invalid date" 1`] = `"Time cannot represent an invalid time-string Invalid date."`;
+exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "Invalid date" 1`] = `"Time cannot represent an invalid time-string \\"Invalid date\\""`;
 
 exports[`GraphQLTime value parsing throws an error when parsing [] 1`] = `"Time cannot represent non string type []"`;
 

--- a/src/time/__snapshots__/index.test.js.snap
+++ b/src/time/__snapshots__/index.test.js.snap
@@ -2,17 +2,17 @@
 
 exports[`GraphQLTime has a description 1`] = `"A time string at UTC, such as 10:15:30Z, compliant with the \`full-time\` format outlined in section 5.6 of the RFC 3339profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."`;
 
-exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "FloatValue", "value": "5"} 1`] = `"Time cannot represent non string type null"`;
+exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "FloatValue", "value": "5"} 1`] = `"Can't parse non-string type: null"`;
 
-exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "00:00:00.45+01"} 1`] = `"Time cannot represent an invalid time-string \\"00:00:00.45+01\\""`;
+exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "00:00:00.45+01"} 1`] = `"Can't parse an invalid Time string: \\"00:00:00.45+01\\""`;
 
-exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "00:00:00.45+0130"} 1`] = `"Time cannot represent an invalid time-string \\"00:00:00.45+0130\\""`;
+exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "00:00:00.45+0130"} 1`] = `"Can't parse an invalid Time string: \\"00:00:00.45+0130\\""`;
 
-exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "10:30:02.Z"} 1`] = `"Time cannot represent an invalid time-string \\"10:30:02.Z\\""`;
+exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "10:30:02.Z"} 1`] = `"Can't parse an invalid Time string: \\"10:30:02.Z\\""`;
 
-exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-01-01T00:00:00.223Z"} 1`] = `"Time cannot represent an invalid time-string \\"2016-01-01T00:00:00.223Z\\""`;
+exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "2016-01-01T00:00:00.223Z"} 1`] = `"Can't parse an invalid Time string: \\"2016-01-01T00:00:00.223Z\\""`;
 
-exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "Invalid date"} 1`] = `"Time cannot represent an invalid time-string \\"Invalid date\\""`;
+exports[`GraphQLTime literal parsing throws error when parsing invalid literal {"kind": "StringValue", "value": "Invalid date"} 1`] = `"Can't parse an invalid Time string: \\"Invalid date\\""`;
 
 exports[`GraphQLTime serialization throws an error when serializing an invalid date-string "00:00:00.45+01" 1`] = `"Time cannot represent an invalid time-string 00:00:00.45+01."`;
 
@@ -36,22 +36,22 @@ exports[`GraphQLTime serialization throws error when serializing true 1`] = `"Ti
 
 exports[`GraphQLTime serialization throws error when serializing undefined 1`] = `"Time cannot be serialized from a non string, or non Date type undefined"`;
 
-exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "00:00:00.45+01" 1`] = `"Time cannot represent an invalid time-string \\"00:00:00.45+01\\""`;
+exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "00:00:00.45+01" 1`] = `"Can't parse an invalid Time string: \\"00:00:00.45+01\\""`;
 
-exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "00:00:00.45+0130" 1`] = `"Time cannot represent an invalid time-string \\"00:00:00.45+0130\\""`;
+exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "00:00:00.45+0130" 1`] = `"Can't parse an invalid Time string: \\"00:00:00.45+0130\\""`;
 
-exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "10:30:02.Z" 1`] = `"Time cannot represent an invalid time-string \\"10:30:02.Z\\""`;
+exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "10:30:02.Z" 1`] = `"Can't parse an invalid Time string: \\"10:30:02.Z\\""`;
 
-exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "2016-01-01T00:00:00.223Z" 1`] = `"Time cannot represent an invalid time-string \\"2016-01-01T00:00:00.223Z\\""`;
+exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "2016-01-01T00:00:00.223Z" 1`] = `"Can't parse an invalid Time string: \\"2016-01-01T00:00:00.223Z\\""`;
 
-exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "Invalid date" 1`] = `"Time cannot represent an invalid time-string \\"Invalid date\\""`;
+exports[`GraphQLTime value parsing throws an error parsing an invalid time-string "Invalid date" 1`] = `"Can't parse an invalid Time string: \\"Invalid date\\""`;
 
-exports[`GraphQLTime value parsing throws an error when parsing [] 1`] = `"Time cannot represent non string type []"`;
+exports[`GraphQLTime value parsing throws an error when parsing [] 1`] = `"Can't parse non-string type: []"`;
 
-exports[`GraphQLTime value parsing throws an error when parsing {} 1`] = `"Time cannot represent non string type {}"`;
+exports[`GraphQLTime value parsing throws an error when parsing {} 1`] = `"Can't parse non-string type: {}"`;
 
-exports[`GraphQLTime value parsing throws an error when parsing 4566 1`] = `"Time cannot represent non string type 4566"`;
+exports[`GraphQLTime value parsing throws an error when parsing 4566 1`] = `"Can't parse non-string type: 4566"`;
 
-exports[`GraphQLTime value parsing throws an error when parsing null 1`] = `"Time cannot represent non string type null"`;
+exports[`GraphQLTime value parsing throws an error when parsing null 1`] = `"Can't parse non-string type: null"`;
 
-exports[`GraphQLTime value parsing throws an error when parsing true 1`] = `"Time cannot represent non string type true"`;
+exports[`GraphQLTime value parsing throws an error when parsing true 1`] = `"Can't parse non-string type: true"`;

--- a/src/time/index.test.js
+++ b/src/time/index.test.js
@@ -136,7 +136,7 @@ describe('GraphQLTime', () => {
     })
   })
 
-  describe('literial parsing', () => {
+  describe('literal parsing', () => {
     validDates.forEach(([ value, expected ]) => {
       const literal = {
         kind: Kind.STRING, value
@@ -153,20 +153,20 @@ describe('GraphQLTime', () => {
       const invalidLiteral = {
         kind: Kind.STRING, value
       }
-      it(`returns null when parsing invalid literal ${stringify(invalidLiteral)}`, () => {
-        expect(
+      it(`throws error when parsing invalid literal ${stringify(invalidLiteral)}`, () => {
+        expect(() =>
           GraphQLTime.parseLiteral(invalidLiteral)
-        ).toEqual(null)
+        ).toThrowErrorMatchingSnapshot()
       })
     })
 
     const invalidLiteralFloat = {
       kind: Kind.FLOAT, value: '5'
     }
-    it(`returns null when parsing invalid literal ${stringify(invalidLiteralFloat)}`, () => {
-      expect(
+    it(`throws error when parsing invalid literal ${stringify(invalidLiteralFloat)}`, () => {
+      expect(() =>
         GraphQLTime.parseLiteral(invalidLiteralFloat)
-      ).toEqual(null)
+      ).toThrowErrorMatchingSnapshot()
     })
   })
 })

--- a/src/utils/createParseHandler.js
+++ b/src/utils/createParseHandler.js
@@ -10,14 +10,14 @@ export default function createParseHandler(
   return (value: mixed, ast: ?ASTNode): Date => {
     if (!(typeof value === 'string' || value instanceof String)) {
       throw new GraphQLError(
-        `${typeName} cannot represent non string type ${JSON.stringify(value)}`,
+        `Can't parse non-string type: ${JSON.stringify(value)}`,
         ast ? [ast] : undefined
       )
     }
 
     if (!validateValue(value)) {
       throw new GraphQLError(
-        `${typeName} cannot represent an invalid time-string ${JSON.stringify(value)}`,
+        `Can't parse an invalid ${typeName} string: ${JSON.stringify(value)}`,
         ast ? [ast] : undefined
       )
     }

--- a/src/utils/createParseHandler.js
+++ b/src/utils/createParseHandler.js
@@ -1,0 +1,27 @@
+// @flow
+import type { ASTNode } from 'graphql';
+import { GraphQLError } from 'graphql/error'
+
+export default function createParseHandler(
+  typeName: string,
+  validateValue: (value: string) => boolean,
+  parseValue: (value: string) => Date
+) {
+  return (value: mixed, ast: ?ASTNode): Date => {
+    if (!(typeof value === 'string' || value instanceof String)) {
+      throw new GraphQLError(
+        `${typeName} cannot represent non string type ${JSON.stringify(value)}`,
+        ast ? [ast] : undefined
+      )
+    }
+
+    if (!validateValue(value)) {
+      throw new GraphQLError(
+        `${typeName} cannot represent an invalid time-string ${JSON.stringify(value)}`,
+        ast ? [ast] : undefined
+      )
+    }
+    
+    return parseValue(value)
+  }
+}

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -27,3 +27,5 @@ export {
   validateUnixTimestamp,
   validateJSDate
 } from './validator'
+
+export { default as createParseHandler } from './createParseHandler'


### PR DESCRIPTION
I ran into the problem that things worked differently across types and that the `parseLiteral()` didn't throw like `parseValue()` did.

I created a `createParseHandler(): Function` that returns a function that can be used in `parseLiteral()` and `parseValue()` functions.

Closes #72 