### PR TITLE
Added integration tests

### DIFF
--- a/src/date/integration.test.js
+++ b/src/date/integration.test.js
@@ -1,0 +1,202 @@
+// @flow
+/**
+ * Copyright (c) 2018, Dirk-Jan Rutten
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+ import { graphql, GraphQLObjectType, GraphQLSchema, GraphQLError, GraphQLInputObjectType } from 'graphql'
+ import GraphQLDate from './'
+
+ const schema = new GraphQLSchema({
+   query: new GraphQLObjectType({
+     name: 'Query',
+     fields: {
+       validDate: {
+         type: GraphQLDate,
+         resolve: () => new Date("2016-05-02")
+       },
+       validDateString: {
+         type: GraphQLDate,
+         resolve: () => '1991-12-24'
+       },
+       invalidDateString: {
+         type: GraphQLDate,
+         resolve: () => '2017-01-001'
+       },
+       invalidDate: {
+         type: GraphQLDate,
+         resolve: () => new Date("wrong")
+       },
+       invalidType: {
+         type: GraphQLDate,
+         resolve: () => 5
+       },
+       input: {
+         type: GraphQLDate,
+         args: {
+           date: {
+             type: GraphQLDate
+           }
+         },
+         resolve: (_, input: { date: Date }) => input.date
+       }
+     }
+   })
+ });
+ 
+ it("executes a query that includes a date", async () => {
+   const query = `
+     query DateTest($date: Date!) {
+       validDate
+       validDateString
+       input(date: $date)
+     }
+   `;
+
+   const variables = { date: '2017-10-01' }
+
+   const response = await graphql(schema, query, null, null, variables);
+   
+   expect(response).toEqual({
+     data: {
+       validDate: "2016-05-02",
+       input: "2017-10-01",
+       validDateString: "1991-12-24"
+     }
+   });
+ });
+ 
+ it("parses input to a JS Date", done => {
+   const schema = new GraphQLSchema({
+     query: new GraphQLObjectType({
+       name: 'Query',
+       fields: {
+         input: {
+           type: GraphQLDate,
+           args: {
+             date: {
+               type: GraphQLDate
+             }
+           },
+           resolve: (_, input) => {
+             try {
+               expect(input.date).toEqual(new Date(Date.UTC(2016, 11, 17)));
+               done();
+             } catch(e) {
+               done.fail(e);
+             }
+           }
+       }
+     }
+   })
+   });
+   
+   const query = `
+     query DateTest($date: Date!) {
+       input(date: $date)
+     }
+   `;
+   const variables = { date: '2016-12-17' }
+
+   graphql(schema, query, null, null, variables);
+ });
+ 
+ it("errors if there is an invalid date returned from the resolver", async () => {
+   const query = `
+     {
+       invalidDateString
+       invalidDate
+       invalidType
+     }
+   `;
+
+
+   const response = await graphql(schema, query);
+   
+   expect(response).toEqual({
+     data: {
+       invalidDateString: null,
+       invalidDate: null,
+       invalidType: null
+     },
+     errors: [
+       new GraphQLError("Date cannot represent an invalid date-string 2017-01-001."),
+       new GraphQLError("Date cannot represent an invalid Date instance"),
+       new GraphQLError("Date cannot represent a non string, or non Date type 5")
+     ]
+   });
+ });
+ 
+ it("errors if the variable value is not a valid date", async () => {
+   const query = `
+     query DateTest($date: Date!) {
+       input(date: $date)
+     }
+   `;
+
+   const variables = { date: '2017-10-001' }
+
+   const response = await graphql(schema, query, null, null, variables);
+   
+   expect(response).toEqual({
+     errors: [
+       new GraphQLError("Variable \"$date\" got invalid value \"2017-10-001\"; Expected type Date; Date cannot represent an invalid date-string 2017-10-001.")
+     ]
+   }); 
+ });
+ 
+ it("errors if the variable value is not of type string", async () => {
+   const query = `
+     query DateTest($date: Date!) {
+       input(date: $date)
+     }
+   `;
+
+   const variables = { date: 4 }
+
+   const response = await graphql(schema, query, null, null, variables);
+   
+   expect(response).toEqual({
+     errors: [
+       new GraphQLError("Variable \"$date\" got invalid value 4; Expected type Date; Date cannot represent non string type 4")
+     ]
+   }); 
+ });
+ 
+ it("errors if the literal input value is not a valid date", async () => {
+   const query = `
+     {
+       input(date: "2017-10-001")
+     }
+   `;
+
+   const response = await graphql(schema, query);
+   
+   expect(response).toEqual({
+     data: {
+     //TODO: This is a bug. It should error.
+     input: null
+   }
+   }); 
+ });
+ 
+ it("errors if the literal input value in a query is not a string", async () => {
+   const query = `
+     {
+       input(date: 4)
+     }
+   `;
+
+   const response = await graphql(schema, query);
+   
+   expect(response).toEqual({
+     data: {
+     //TODO: This is a bug. It should error.
+     input: null
+   }
+   }); 
+ });

--- a/src/dateTime/integration.test.js
+++ b/src/dateTime/integration.test.js
@@ -1,0 +1,238 @@
+// @flow
+/**
+ * Copyright (c) 2018, Dirk-Jan Rutten
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+ import { graphql, GraphQLObjectType, GraphQLSchema, GraphQLError, GraphQLInputObjectType, GraphQLInt } from 'graphql'
+ import GraphQLDateTime from './'
+
+ const schema = new GraphQLSchema({
+   query: new GraphQLObjectType({
+     name: 'Query',
+     fields: {
+       validDate: {
+         type: GraphQLDateTime,
+         resolve: () => new Date("2016-05-02T10:31:42.2Z")
+       },
+       validUTCDateString: {
+         type: GraphQLDateTime,
+         resolve: () => '1991-12-24T00:00:00Z'
+       },
+       validDateString: {
+         type: GraphQLDateTime,
+         resolve: () => '2016-02-01T00:00:00-11:00'
+       },
+       validUnixTimestamp: {
+         type: GraphQLDateTime,
+         resolve: () => 854325678
+       },
+       invalidDateString: {
+         type: GraphQLDateTime,
+         resolve: () => '2017-01-001T00:00:00Z'
+       },
+       invalidDate: {
+         type: GraphQLDateTime,
+         resolve: () => new Date("wrong")
+       },
+       invalidUnixTimestamp: {
+         type: GraphQLDateTime,
+         resolve: () => Number.POSITIVE_INFINITY
+       },
+       invalidType: {
+         type: GraphQLDateTime,
+         resolve: () => []
+       },
+       input: {
+         type: GraphQLDateTime,
+         args: {
+           date: {
+             type: GraphQLDateTime
+           }
+         },
+         resolve: (_, input: { date: Date }) => input.date
+       }
+     }
+   })
+ });
+ 
+ it("executes a query that includes a DateTime", async () => {
+   const query = `
+     query DateTest($date: DateTime!) {
+       validDate
+       validUTCDateString,
+       validDateString
+       validUnixTimestamp
+       input(date: $date)
+     }
+   `;
+
+   const variables = { date: '2017-10-01T00:00:00Z' }
+
+   const response = await graphql(schema, query, null, null, variables);
+   
+   expect(response).toEqual({
+     data: {
+       validDate: "2016-05-02T10:31:42.200Z",
+       validUTCDateString: "1991-12-24T00:00:00Z",
+       validDateString: '2016-02-01T11:00:00Z',
+       input: "2017-10-01T00:00:00.000Z",
+       validUnixTimestamp: "1997-01-27T00:41:18.000Z"
+     }
+   });
+ });
+ 
+ it("shifts an input date-time to UTC", async () => {
+   const query = `
+     query DateTest($date: DateTime!) {
+       input(date: $date)
+     }
+   `;
+
+   const variables = { date: '2016-02-01T00:00:00-11:00' }
+
+   const response = await graphql(schema, query, null, null, variables);
+   
+   expect(response).toEqual({
+     data: {
+       input: "2016-02-01T11:00:00.000Z"
+     }
+   });
+ });
+ 
+ it("parses input to a JS Date", done => {
+   const schema = new GraphQLSchema({
+     query: new GraphQLObjectType({
+       name: 'Query',
+       fields: {
+         input: {
+           type: GraphQLDateTime,
+           args: {
+             date: {
+               type: GraphQLDateTime
+             }
+           },
+           resolve: (_, input) => {
+             try {
+               expect(input.date).toEqual(new Date(Date.UTC(2016, 1, 1, 0, 0, 15)));
+               done();
+             } catch(e) {
+               done.fail(e);
+             }
+           }
+       }
+     }
+   })
+   });
+   
+   const query = `
+     query DateTest($date: DateTime!) {
+       input(date: $date)
+     }
+   `;
+   const variables = { date: '2016-02-01T00:00:15Z' }
+
+   graphql(schema, query, null, null, variables);
+ });
+ 
+ it("errors if an invalid date-time is returned from the resolver", async () => {
+   const query = `
+     {
+       invalidDateString
+       invalidDate
+       invalidUnixTimestamp
+       invalidType
+     }
+   `;
+
+   const response = await graphql(schema, query);
+   
+   expect(response).toEqual({
+     data: {
+       invalidDateString: null,
+       invalidDate: null,
+       invalidUnixTimestamp: null,
+       invalidType: null
+     },
+     errors: [
+       new GraphQLError("DateTime cannot represent an invalid date-time-string 2017-01-001T00:00:00Z."),
+       new GraphQLError("DateTime cannot represent an invalid Date instance"),
+       new GraphQLError("DateTime cannot represent an invalid Unix timestamp Infinity"),
+       new GraphQLError("DateTime cannot be serialized from a non string, non numeric or non Date type []")
+     ]
+   });
+ });
+ 
+ it("errors if the variable value is not a valid date-time", async () => {
+   const query = `
+     query DateTest($date: DateTime!) {
+       input(date: $date)
+     }
+   `;
+
+   const variables = { date: '2017-10-001T00:00:00Z' }
+
+   const response = await graphql(schema, query, null, null, variables);
+   
+   expect(response).toEqual({
+     errors: [
+       new GraphQLError("Variable \"$date\" got invalid value \"2017-10-001T00:00:00Z\"; Expected type DateTime; DateTime cannot represent an invalid date-time-string 2017-10-001T00:00:00Z.")
+     ]
+   }); 
+ });
+ 
+ it("errors if the variable value is not of type string", async () => {
+   const query = `
+     query DateTest($date: DateTime!) {
+       input(date: $date)
+     }
+   `;
+
+   const variables = { date: 4 }
+
+   const response = await graphql(schema, query, null, null, variables);
+   
+   expect(response).toEqual({
+     errors: [
+       new GraphQLError("Variable \"$date\" got invalid value 4; Expected type DateTime; DateTime cannot represent non string type 4")
+     ]
+   }); 
+ });
+ 
+ it("errors if the literal input value is not a valid date-time", async () => {
+   const query = `
+     {
+       input(date: "2017-10-001T00:00:00")
+     }
+   `;
+
+   const response = await graphql(schema, query);
+   
+   expect(response).toEqual({
+     data: {
+     //TODO: This is a bug. It should error.
+     input: null
+   }
+   }); 
+ });
+ 
+ it("errors if the literal input value in a query is not a string", async () => {
+   const query = `
+     {
+       input(date: 4)
+     }
+   `;
+
+   const response = await graphql(schema, query);
+   
+   expect(response).toEqual({
+     data: {
+     //TODO: This is a bug. It should error.
+     input: null
+   }
+   }); 
+ });

--- a/src/time/integration.test.js
+++ b/src/time/integration.test.js
@@ -1,0 +1,232 @@
+// @flow
+/**
+ * Copyright (c) 2018, Dirk-Jan Rutten
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+ import { graphql, GraphQLObjectType, GraphQLSchema, GraphQLError, GraphQLInputObjectType } from 'graphql'
+ import GraphQLTime from './'
+ // flowlint-next-line untyped-import:off
+ import MockDate from 'mockdate'
+
+ // Mock the new Date() call so it always returns 2017-01-01T00:00:00.000Z
+ MockDate.set(new Date(Date.UTC(2017, 0, 1)))
+ 
+ const schema = new GraphQLSchema({
+   query: new GraphQLObjectType({
+     name: 'Query',
+     fields: {
+       validJSDate: {
+         type: GraphQLTime,
+         resolve: () => new Date(Date.UTC(2016, 0, 1, 14, 48, 10, 3))
+       },
+       validUTCTimeString: {
+         type: GraphQLTime,
+         resolve: () => '14:30:00Z'
+       },
+       validTimeString: {
+         type: GraphQLTime,
+         resolve: () => '00:00:00+01:30'
+       },
+       invalidTimeString: {
+         type: GraphQLTime,
+         resolve: () => "2222",
+       },
+       invalidJSDate: {
+         type: GraphQLTime,
+         resolve: () => new Date("wrong")
+       },
+       invalidType: {
+         type: GraphQLTime,
+         resolve: () => 5
+       },
+       input: {
+         type: GraphQLTime,
+         args: {
+           time: {
+             type: GraphQLTime
+           }
+         },
+         resolve: (_, input) => input.time
+     }
+   }
+ })
+ });
+ 
+ it("executes a query that includes a time", async () => {
+   const query = `
+     query TimeTest($time: Time!) {
+       validJSDate
+       validUTCTimeString
+       validTimeString
+       input(time: $time)
+     }
+   `;
+
+   const variables = { time: '14:30:00Z' }
+
+   const response = await graphql(schema, query, null, null, variables);
+   
+   expect(response).toEqual({
+     data: {
+       validJSDate: '14:48:10.003Z',
+       validUTCTimeString: "14:30:00Z",
+       validTimeString: '22:30:00Z',
+       input: "14:30:00.000Z",
+     }
+   });
+ });
+ 
+ it("shifts an input time to UTC", async () => {
+   const query = `
+     query TimeTest($time: Time!) {
+       input(time: $time)
+     }
+   `;
+
+   const variables = { time: '00:00:00+01:30' }
+
+   const response = await graphql(schema, query, null, null, variables);
+   
+   expect(response).toEqual({
+     data: {
+       input: "22:30:00.000Z"
+     }
+   });
+ });
+ 
+ it("parses input to a JS Date", done => {
+   const schema = new GraphQLSchema({
+     query: new GraphQLObjectType({
+       name: 'Query',
+       fields: {
+         input: {
+           type: GraphQLTime,
+           args: {
+             time: {
+               type: GraphQLTime
+             }
+           },
+           resolve: (_, input) => {
+             try {
+               expect(input.time).toEqual(new Date(Date.UTC(2016, 11, 31, 22, 30)));
+               done();
+             } catch(e) {
+               done.fail(e);
+             }
+           }
+       }
+     }
+   })
+   });
+   
+   const query = `
+     query TimeTest($time: Time!) {
+       input(time: $time)
+     }
+   `;
+
+   const variables = { time: '00:00:00+01:30' }
+
+   graphql(schema, query, null, null, variables);
+ });
+ 
+ it("errors if there is an invalid time returned from the resolver", async () => {
+   const query = `
+     {
+       invalidTimeString
+       invalidJSDate
+       invalidType
+     }
+   `;
+ 
+ 
+   const response = await graphql(schema, query);
+ 
+   expect(response).toEqual({
+     data: {
+       invalidTimeString: null,
+       invalidJSDate: null,
+       invalidType: null
+     },
+     errors: [
+       new GraphQLError("Time cannot represent an invalid time-string 2222."),
+       new GraphQLError("Time cannot represent an invalid Date instance"),
+       new GraphQLError("Time cannot be serialized from a non string, or non Date type 5")
+     ]
+   });
+ });
+ 
+ it("errors if the variable value is not a valid time", async () => {
+   const query = `
+     query TimeTest($time: Time!) {
+       input(time: $time)
+     }
+   `;
+ 
+   const variables = { time: '__2222' }
+ 
+   const response = await graphql(schema, query, null, null, variables);
+ 
+   expect(response).toEqual({
+     errors: [
+       new GraphQLError("Variable \"$time\" got invalid value \"__2222\"; Expected type Time; Time cannot represent an invalid time-string __2222.")
+     ]
+   }); 
+ });
+ 
+ it("errors if the variable value is not of type string", async () => {
+   const query = `
+     query DateTest($time: Time!) {
+       input(time: $time)
+     }
+   `;
+ 
+   const variables = { time: 4 }
+ 
+   const response = await graphql(schema, query, null, null, variables);
+ 
+   expect(response).toEqual({
+     errors: [
+       new GraphQLError("Variable \"$time\" got invalid value 4; Expected type Time; Time cannot represent non string type 4")
+     ]
+   }); 
+ });
+ 
+ it("errors if the literal input value is not a valid time", async () => {
+   const query = `
+     {
+       input(time: "__invalid__")
+     }
+   `;
+ 
+   const response = await graphql(schema, query);
+ 
+   expect(response).toEqual({
+     data: {
+     //TODO: This is a bug. It should error.
+     input: null
+   }
+   }); 
+ });
+ 
+ it("errors if the literal input value in a query is not a string", async () => {
+   const query = `
+     {
+       input(time: 4)
+     }
+   `;
+ 
+   const response = await graphql(schema, query);
+ 
+   expect(response).toEqual({
+     data: {
+     //TODO: This is a bug. It should error.
+     input: null
+   }
+   }); 
+ });


### PR DESCRIPTION
Implemented some integration tests to reproduce issue #72 for invalid literal input. These tests run against an actual graphQL schema

Note, this PR does not fix issue #72. It only reproduces it.