### PR TITLE
Strip time component of parsed Date

### DIFF
--- a/src/date/index.js
+++ b/src/date/index.js
@@ -55,9 +55,9 @@ const config: GraphQLScalarTypeConfig<Date, string> = {
         `Date cannot represent non string type ${JSON.stringify(value)}`
       )
     }
-
-    if (validateDate(value)) {
-      return parseDate(value)
+    const trimmedValue = value.split('T')[0]
+    if (validateDate(trimmedValue)) {
+      return parseDate(trimmedValue)
     }
     throw new TypeError(
       `Date cannot represent an invalid date-string ${value}.`
@@ -70,8 +70,9 @@ const config: GraphQLScalarTypeConfig<Date, string> = {
       )
     }
     const { value } = ast
-    if (validateDate(value)) {
-      return parseDate(value)
+    const trimmedValue = value.split('T')[0]
+    if (validateDate(trimmedValue)) {
+      return parseDate(trimmedValue)
     }
     throw new TypeError(
       `Date cannot represent an invalid date-string ${String(value)}.`


### PR DESCRIPTION
Fixes #106.

This PR strips the time component from a date string when being parsed as a `GraphQLDate` to allow services both using `GraphQLDate` fields to delegate to each other.